### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/clevercloud/jar.json
+++ b/clevercloud/jar.json
@@ -4,6 +4,6 @@
     "goal": "assemble"
   },
   "deploy": {
-    "jarName": "build/libs/reactor-bot-0.0.2-SNAPSHOT.jar"
+    "jarName": "build/libs/reactor-bot-0.0.3-SNAPSHOT.jar"
   }
 }

--- a/clevercloud/jar.json
+++ b/clevercloud/jar.json
@@ -4,6 +4,6 @@
     "goal": "assemble"
   },
   "deploy": {
-    "jarName": "build/libs/reactor-bot-0.0.1-SNAPSHOT.jar"
+    "jarName": "build/libs/reactor-bot-0.0.2-SNAPSHOT.jar"
   }
 }

--- a/clevercloud/jar.json
+++ b/clevercloud/jar.json
@@ -1,0 +1,9 @@
+{
+  "build": {
+    "type": "gradle",
+    "goal": "assemble"
+  },
+  "deploy": {
+    "jarName": "build/libs/reactor-bot-0.0.1-SNAPSHOT.jar"
+  }
+}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).