### PR TITLE
Activate forward-merge hint on *.x branches via opt-in

### DIFF
--- a/src/main/java/io/projectreactor/bot/config/LocalSettingsEnvironmentPostProcessor.java
+++ b/src/main/java/io/projectreactor/bot/config/LocalSettingsEnvironmentPostProcessor.java
@@ -4,12 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
-import org.springframework.core.env.CommandLinePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertiesPropertySource;
@@ -31,16 +27,8 @@ public class LocalSettingsEnvironmentPostProcessor implements EnvironmentPostPro
 			MutablePropertySources propertySources = configurableEnvironment.getPropertySources();
 			System.out.println("Loading local settings from " + file.getAbsolutePath());
 			Properties properties = loadProperties(file);
-			if (propertySources.contains(
-					CommandLinePropertySource.COMMAND_LINE_PROPERTY_SOURCE_NAME)) {
-				propertySources.addAfter(
-						CommandLinePropertySource.COMMAND_LINE_PROPERTY_SOURCE_NAME,
-						new PropertiesPropertySource("reactor-bot-local", properties));
-			}
-			else {
-				propertySources
-						.addFirst(new PropertiesPropertySource("reactor-bot-local", properties));
-			}
+			propertySources.addBefore("applicationConfig: [classpath:/application.properties]",
+					new PropertiesPropertySource("reactor-bot-local", properties));
 		}
 		else {
 			System.out.println("Could not find local settings, no " + file.getAbsolutePath());

--- a/src/main/kotlin/io/projectreactor/bot/config/GitHubProperties.kt
+++ b/src/main/kotlin/io/projectreactor/bot/config/GitHubProperties.kt
@@ -12,6 +12,8 @@ class GitHubProperties {
     var token: String? = "INVALID"
     var noCancel: Boolean = false
 
+    val mergeHintRepos: MutableList<String> = mutableListOf()
+
     val repos: MutableMap<String, Repo> = mutableMapOf()
 
     class Repo {

--- a/src/main/kotlin/io/projectreactor/bot/config/GitHubProperties.kt
+++ b/src/main/kotlin/io/projectreactor/bot/config/GitHubProperties.kt
@@ -17,8 +17,8 @@ class GitHubProperties {
     class Repo {
         var org: String = "INVALID"
         var repo: String = "INVALID"
-        var watchedLabel: String = "INVALID"
-        var triageLabel: String? = "INVALID"
+        var watchedLabel: String = "INVALIDLABEL"
+        var triageLabel: String? = "INVALIDLABEL"
         /**
          * Map of maintainer information: keys are github handles with '@', values
          * are Slack UIDs.

--- a/src/main/kotlin/io/projectreactor/bot/github/GithubController.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/GithubController.kt
@@ -27,30 +27,41 @@ class GithubController(val fastTrackService: FastTrackService,
 
     @PostMapping("/gh/pr", consumes = [(MediaType.APPLICATION_JSON_VALUE)])
     fun prHook(@RequestBody event: PrUpdate): Mono<ResponseEntity<String>> {
-        //we need to fallback on synthetic repo to enable blanket hint for PRs merged on maintenance branch
-        val repo = fastTrackService.findRepoConfigOrCommonConfig(event.repository) ?:
-                return ResponseEntity.noContent().build<String>().toMono()
+        //we distinguish the fast track case from the issue merged case by processing closed first
+        if (event.action == "closed") {
+            if (event.pull_request.merged && event.pull_request.base != null
+                    && event.pull_request.base.ref.endsWith(".x")) {
 
-        if (event.action == "labeled" && event.label?.name == repo.watchedLabel) {
-            return fastTrackService.fastTrack(event, repo)
-                    .timeout(Duration.ofSeconds(4))
+                val mergeHintEnabled = ghProps.mergeHintRepos.contains(event.repository.full_name)
+                if (mergeHintEnabled) {
+
+                    val repo = fastTrackService.findExactRepoConfig(event.repository)
+                    val repoMaintainers = repo?.maintainers?.keys ?: emptySet<String>()
+
+                    val maintainersToPing = maintainersToPing(
+                            event.pull_request.author.login,
+                            event.pull_request.merged_by?.login,
+                            repoMaintainers)
+
+                    return issueService.comment("$maintainersToPing this PR seems to have been merged on a maintenance branch, please ensure the change is merge-forwarded to intermediate maintenance branches and up to `master` :bow:",
+                            event.pull_request, event.repository.full_name)
+                            .map { ResponseEntity.ok(it?.toString() ?: "") }
+                }
+            }
         }
+        else {
+            val repo = fastTrackService.findExactRepoConfig(event.repository)
+                    ?: return ResponseEntity.noContent().build<String>().toMono()
 
-        if (event.action == "unlabeled" && event.label?.name == repo.watchedLabel) {
-            return fastTrackService.unfastTrack(event, repo)
-                    .timeout(Duration.ofSeconds(4))
-        }
+            if (event.action == "labeled" && event.label?.name == repo.watchedLabel) {
+                return fastTrackService.fastTrack(event, repo)
+                        .timeout(Duration.ofSeconds(4))
+            }
 
-        if (event.action == "closed" && event.pull_request.merged && event.pull_request.base != null
-                && event.pull_request.base.ref.endsWith(".x")) {
-            val maintainersToPing = maintainersToPing(
-                    event.pull_request.author.login,
-                    event.pull_request.merged_by?.login,
-                    repo.maintainers.keys)
-
-            return issueService.comment("$maintainersToPing this PR seems to have been merged on a maintenance branch, please ensure the change is merge-forwarded to intermediate maintenance branches and up to `master` :bow:",
-                                event.pull_request, repo)
-                    .map { ResponseEntity.ok(it?.toString() ?: "") }
+            if (event.action == "unlabeled" && event.label?.name == repo.watchedLabel) {
+                return fastTrackService.unfastTrack(event, repo)
+                        .timeout(Duration.ofSeconds(4))
+            }
         }
 
         return ResponseEntity.noContent().build<String>().toMono()
@@ -75,6 +86,7 @@ class GithubController(val fastTrackService: FastTrackService,
     @PostMapping("gh/issue", consumes = [(MediaType.APPLICATION_JSON_VALUE)])
     fun issueHook(@RequestBody issueEvent: IssuesEvent): Mono<ResponseEntity<String>> {
         //we need to fallback on synthetic repo to enable blanket triage labelling
+        //note that projects which don't even have the common label won't be notified
         val repoProp = fastTrackService.findRepoConfigOrCommonConfig(issueEvent.repository) ?:
                 return ResponseEntity.noContent().build<String>().toMono()
 

--- a/src/main/kotlin/io/projectreactor/bot/service/IssueService.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/IssueService.kt
@@ -61,15 +61,17 @@ class IssueService(@Qualifier("githubClient") val client: WebClient) {
                 .doOnSuccess { LOG.debug("Done: Applying label") }
     }
 
-    fun comment(comment: String, issue: IssueOrPr, repo: Repo): Mono<String> {
-        val owner = "${repo.org}/${repo.repo}"
+    fun comment(comment: String, issue: IssueOrPr, repo: Repo): Mono<String>
+        = comment(comment, issue, "${repo.org}/${repo.repo}")
+
+    fun comment(comment: String, issue: IssueOrPr, repoFullName: String): Mono<String> {
         val number = issue.number
         return client.post()
-                .uri("/repos/$owner/issues/$number/comments")
+                .uri("/repos/$repoFullName/issues/$number/comments")
                 .bodyValue("{\"body\": \"$comment\"}")
                 .retrieve()
                 .bodyToMono<String>()
-                .doFirst { LOG.debug("Commenting on ${repo.org}/${repo.repo}#${issue.number}") }
+                .doFirst { LOG.debug("Commenting on ${repoFullName}#${issue.number}") }
                 .doOnError {
                     if (it is WebClientResponseException) {
                         LOG.error("GitHub error commenting: ${it.message}" +

--- a/src/test/kotlin/io/projectreactor/bot/BotApplicationTests.kt
+++ b/src/test/kotlin/io/projectreactor/bot/BotApplicationTests.kt
@@ -3,9 +3,11 @@ package io.projectreactor.bot
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
+@ActiveProfiles("test")
 @SpringBootTest
 class BotApplicationTests {
 

--- a/src/test/kotlin/io/projectreactor/bot/config/GitHubPropertiesTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/config/GitHubPropertiesTest.kt
@@ -19,7 +19,7 @@ class GitHubPropertiesTest {
     @Test
     fun hasMergeHintRepoList() {
         assertThat(config?.mergeHintRepos)
-                .contains("reactor/reactor-core", "reactor/reactor-pool")
+                .contains("org/example1", "org/example2")
     }
 
     @Test

--- a/src/test/kotlin/io/projectreactor/bot/config/GitHubPropertiesTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/config/GitHubPropertiesTest.kt
@@ -1,0 +1,30 @@
+package io.projectreactor.bot.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@SpringBootTest
+@ActiveProfiles("test")
+class GitHubPropertiesTest {
+
+    @Autowired
+    private var config: GitHubProperties? = null
+
+    @Test
+    fun hasMergeHintRepoList() {
+        assertThat(config?.mergeHintRepos)
+                .contains("reactor/reactor-core", "reactor/reactor-pool")
+    }
+
+    @Test
+    fun smokeTest() {
+        assertThat(config?.botUsername).isEqualTo("fakebot")
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -24,7 +24,7 @@
 #github.repos.*
 
 github.botUsername=fakebot
-github.mergeHintRepos=reactor/reactor-core,reactor/reactor-pool
+github.mergeHintRepos=org/example1,org/example2
 
 logging.level.io.projectreactor.bot=DEBUG
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,32 @@
+### CONFIGURING FOR PRODUCTION ###
+##################################
+# The configuration includes secrets, commented with a [secret] tag below.
+#
+# IN PRODUCTION THESE SHOULDN'T BE DEFINED IN THIS FILE
+# but via system environment variables...
+#
+# To ease development, these secret can be put in your home directory in a
+# `~/.reactor-bot/reactor-bot.properties` properties file
+##################################
+
+## [secret] Slack webhook to publish messages to
+#slack.incomingWebHook=
+## [secret] Slack oAuth2 token for the bot/app
+#slack.botToken=
+## [secret] The user ID of the bot on Slack, can be found with auth.test Slack API
+#slack.botId=
+## [secret] GitHub bot token
+#github.token=
+
+#these properties are untested for now
+#server.port=9090
+#github.noCancel=false
+#github.repos.*
+
+github.botUsername=fakebot
+github.mergeHintRepos=reactor/reactor-core,reactor/reactor-pool
+
+logging.level.io.projectreactor.bot=DEBUG
+
+management.endpoints.enabled-by-default=false
+management.endpoint.info.enabled=true


### PR DESCRIPTION
This commit enables the forward-merge hint comment on PR close without
an exact Repo subconfiguration. If a Repo exactly matches the PR's, then
the list of maintainers may be used as a fallback for when no merge
information has been provided.

Nonetheless, the main way of activating the feature is to opt-in into it
via the new github.mergeHintRepos list property. Any PR targeting a repo
that isn't in this list will be ignored with 204. It should be safe to
assume that a PR merge would always have merger information, and only
authorize team members can merge anyway, so the Repo configuration isn't
super useful.

Additional polish:

The resolution of repo config now explicitly only look for an exact
match. The methods that look for a common Repo config (with name "*" are
now more explicit about that fact.

The forward-merge hint was previously not issued to repositories without
an exact match in Repo configurations, because the comment is made to
Repo.repo, which was inexisting `*` prior to this change. The order in
which PR webhook criterias are inspected has been reworked.

Tests around the configuration have been added, and the order in which
the property sources are evaluated has been revised so that the custom
property file is injected between application.properties and a potential
application-test.properties:
 - application-test.properties takes precedence in unit tests that have
   the profile active
 - .reactor-bot/reactor-bot.properties allows to run the bot locally and
   perform manual integration testing
 - application.properties has the default base values that aren't secret
