### PR TITLE
Renamed master to main, updated bot 'please forward' message

### DIFF
--- a/src/main/kotlin/io/projectreactor/bot/github/GithubController.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/GithubController.kt
@@ -43,7 +43,7 @@ class GithubController(val fastTrackService: FastTrackService,
                             event.pull_request.merged_by?.login,
                             repoMaintainers)
 
-                    return issueService.comment("$maintainersToPing this PR seems to have been merged on a maintenance branch, please ensure the change is merge-forwarded to intermediate maintenance branches and up to `master` :bow:",
+                    return issueService.comment("$maintainersToPing this PR seems to have been merged on a maintenance branch, please ensure the change is merge-forwarded to intermediate maintenance branches and up to `main` :bow:",
                             event.pull_request, event.repository.full_name)
                             .map { ResponseEntity.ok(it?.toString() ?: "") }
                 }

--- a/src/test/kotlin/io/projectreactor/bot/github/data/PrUpdateTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/github/data/PrUpdateTest.kt
@@ -29,7 +29,7 @@ class PrUpdateTest {
                 "open", "Another proofreading pass", User("Buzzardo"),
                 false,null,null,
                 "CONTRIBUTOR",
-                GitRef("reactor:master", "master","c2111862dd0087c1da9be181c4e0284d74a8f858"))
+                GitRef("reactor:main", "main","c2111862dd0087c1da9be181c4e0284d74a8f858"))
         val expectedRepo = Repository("reactor-core", "reactor/reactor-core")
         val expectedSender = User("simonbasle")
         val expectedLabel = Label("PR-fast-track", "f49b42")

--- a/src/test/kotlin/io/projectreactor/bot/github/data/PullRequestTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/github/data/PullRequestTest.kt
@@ -24,7 +24,7 @@ class PullRequestTest {
                 "open", "Another proofreading pass", User("Buzzardo"),
                 false, null,null,
                 "CONTRIBUTOR",
-                GitRef("reactor:master", "master","c2111862dd0087c1da9be181c4e0284d74a8f858")
+                GitRef("reactor:main", "main","c2111862dd0087c1da9be181c4e0284d74a8f858")
         )
 
         val pr = objectMapper?.readValue<PullRequest>(json)

--- a/src/test/resources/pr.json
+++ b/src/test/resources/pr.json
@@ -157,12 +157,12 @@
       "forks": 0,
       "open_issues": 0,
       "watchers": 0,
-      "default_branch": "master"
+      "default_branch": "main"
     }
   },
   "base": {
-    "label": "reactor:master",
-    "ref": "master",
+    "label": "reactor:main",
+    "ref": "main",
     "sha": "c2111862dd0087c1da9be181c4e0284d74a8f858",
     "user": {
       "login": "reactor",
@@ -270,7 +270,7 @@
       "forks": 157,
       "open_issues": 25,
       "watchers": 975,
-      "default_branch": "master"
+      "default_branch": "main"
     }
   },
   "_links": {

--- a/src/test/resources/prEvent.json
+++ b/src/test/resources/prEvent.json
@@ -96,7 +96,7 @@
     "forks": 157,
     "open_issues": 25,
     "watchers": 975,
-    "default_branch": "master"
+    "default_branch": "main"
   },
   "organization": {
     "login": "reactor",

--- a/src/test/resources/prNoBase.json
+++ b/src/test/resources/prNoBase.json
@@ -157,7 +157,7 @@
       "forks": 0,
       "open_issues": 0,
       "watchers": 0,
-      "default_branch": "master"
+      "default_branch": "main"
     }
   },
   "_links": {


### PR DESCRIPTION
The bot will now talk about `main` branch when reminding about forward
merges in PRs.
