### PR TITLE
Add Spotless and copyright notice headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ buildscript {
 	}
 }
 
+plugins {
+	id "com.diffplug.spotless" version "5.14.0"
+}
+
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-spring'
 apply plugin: 'eclipse'
@@ -35,6 +39,11 @@ apply plugin: 'com.gorylenko.gradle-git-properties'
 group = 'io.projectreactor'
 version = '0.0.4-SNAPSHOT'
 sourceCompatibility = 1.8
+
+ext {
+	isCiServer = System.getenv().containsKey("CI")
+}
+
 compileKotlin {
 	kotlinOptions.jvmTarget = "1.8"
 }
@@ -63,6 +72,33 @@ dependencies {
 
 springBoot {
   buildInfo()
+}
+
+spotless {
+	if (project.hasProperty("spotlessFrom")) {
+		if (project.spotlessFrom == "ALL") {
+			println "[Spotless] Ratchet deactivated"
+		}
+		else {
+			println "[Spotless] Ratchet from $project.spotlessFrom"
+			ratchetFrom project.spotlessFrom
+		}
+	}
+	else if (isCiServer) {
+		println "[Spotless] CI detected without explicit branch, not enforcing check"
+		enforceCheck false
+	}
+	else {
+		String spotlessBranch = "origin/main"
+		println "[Spotless] Local run detected, ratchet from $spotlessBranch"
+		ratchetFrom spotlessBranch
+	}
+	kotlin {
+		licenseHeaderFile('codequality/spotless/licenseSlashstarStyle.txt')
+	}
+	java {
+		licenseHeaderFile('codequality/spotless/licenseSlashstarStyle.txt')
+	}
 }
 
 

--- a/codequality/spotless/licenseSlashstarStyle.txt
+++ b/codequality/spotless/licenseSlashstarStyle.txt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) $YEAR VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/src/main/java/io/projectreactor/bot/config/LocalSettingsEnvironmentPostProcessor.java
+++ b/src/main/java/io/projectreactor/bot/config/LocalSettingsEnvironmentPostProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.config;
 
 import java.io.File;

--- a/src/main/kotlin/io/projectreactor/bot/BotApplication.kt
+++ b/src/main/kotlin/io/projectreactor/bot/BotApplication.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot
 
 import io.projectreactor.bot.config.GitHubProperties

--- a/src/main/kotlin/io/projectreactor/bot/BotApplication.kt
+++ b/src/main/kotlin/io/projectreactor/bot/BotApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/PingController.kt
+++ b/src/main/kotlin/io/projectreactor/bot/PingController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/PingController.kt
+++ b/src/main/kotlin/io/projectreactor/bot/PingController.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot
 
 import org.springframework.http.MediaType

--- a/src/main/kotlin/io/projectreactor/bot/config/BotConfiguration.kt
+++ b/src/main/kotlin/io/projectreactor/bot/config/BotConfiguration.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.config
 
 import org.springframework.context.annotation.Bean

--- a/src/main/kotlin/io/projectreactor/bot/config/BotConfiguration.kt
+++ b/src/main/kotlin/io/projectreactor/bot/config/BotConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/config/GitHubProperties.kt
+++ b/src/main/kotlin/io/projectreactor/bot/config/GitHubProperties.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties

--- a/src/main/kotlin/io/projectreactor/bot/config/SlackProperties.kt
+++ b/src/main/kotlin/io/projectreactor/bot/config/SlackProperties.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/config/SlackProperties.kt
+++ b/src/main/kotlin/io/projectreactor/bot/config/SlackProperties.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties

--- a/src/main/kotlin/io/projectreactor/bot/github/GithubController.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/GithubController.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github
 
 import io.projectreactor.bot.config.GitHubProperties

--- a/src/main/kotlin/io/projectreactor/bot/github/data/CommentEvent.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/CommentEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/CommentEvent.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/CommentEvent.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class CommentEvent(val action: String,

--- a/src/main/kotlin/io/projectreactor/bot/github/data/GitRef.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/GitRef.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class GitRef(val label: String,

--- a/src/main/kotlin/io/projectreactor/bot/github/data/GitRef.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/GitRef.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/IssueOrPr.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/IssueOrPr.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 import com.fasterxml.jackson.annotation.JsonAlias

--- a/src/main/kotlin/io/projectreactor/bot/github/data/IssueOrPr.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/IssueOrPr.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/IssuesEvent.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/IssuesEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/IssuesEvent.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/IssuesEvent.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class IssuesEvent(val action: String,

--- a/src/main/kotlin/io/projectreactor/bot/github/data/Label.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/Label.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class Label(val name: String, val color: String)

--- a/src/main/kotlin/io/projectreactor/bot/github/data/Label.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/Label.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/Organization.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/Organization.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class Organization(val login: String)

--- a/src/main/kotlin/io/projectreactor/bot/github/data/Organization.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/Organization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/PrUpdate.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/PrUpdate.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class PrUpdate(val action: String,

--- a/src/main/kotlin/io/projectreactor/bot/github/data/PrUpdate.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/PrUpdate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/Repository.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/Repository.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class Repository(val name: String, val full_name: String)

--- a/src/main/kotlin/io/projectreactor/bot/github/data/Repository.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/Repository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/ResponseReview.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/ResponseReview.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 /**

--- a/src/main/kotlin/io/projectreactor/bot/github/data/ResponseReview.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/ResponseReview.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/github/data/User.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/User.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 data class User(val login: String)

--- a/src/main/kotlin/io/projectreactor/bot/github/data/User.kt
+++ b/src/main/kotlin/io/projectreactor/bot/github/data/User.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/service/CommentService.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/CommentService.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.service
 
 import io.projectreactor.bot.config.GitHubProperties

--- a/src/main/kotlin/io/projectreactor/bot/service/CommentService.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/CommentService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/service/FastTrackService.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/FastTrackService.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.service
 
 import io.projectreactor.bot.config.GitHubProperties

--- a/src/main/kotlin/io/projectreactor/bot/service/HelpService.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/HelpService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/service/HelpService.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/HelpService.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.service;
 
 

--- a/src/main/kotlin/io/projectreactor/bot/service/IssueService.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/IssueService.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.service
 
 import io.projectreactor.bot.config.GitHubProperties.Repo

--- a/src/main/kotlin/io/projectreactor/bot/service/SlackBot.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/SlackBot.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.service
 
 import io.projectreactor.bot.config.SlackProperties

--- a/src/main/kotlin/io/projectreactor/bot/service/SlackBot.kt
+++ b/src/main/kotlin/io/projectreactor/bot/service/SlackBot.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/slack/SlackController.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/SlackController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/slack/SlackController.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/SlackController.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.slack
 
 import com.fasterxml.jackson.databind.JsonNode

--- a/src/main/kotlin/io/projectreactor/bot/slack/data/Attachment.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/data/Attachment.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2019 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.slack.data
 
 data class Attachment(

--- a/src/main/kotlin/io/projectreactor/bot/slack/data/Attachment.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/data/Attachment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/slack/data/Field.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/data/Field.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.slack.data
 
 data class Field(

--- a/src/main/kotlin/io/projectreactor/bot/slack/data/Field.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/data/Field.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/projectreactor/bot/slack/data/TextMessage.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/data/TextMessage.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.slack.data
 
 import com.fasterxml.jackson.databind.node.ArrayNode

--- a/src/main/kotlin/io/projectreactor/bot/slack/data/TextMessage.kt
+++ b/src/main/kotlin/io/projectreactor/bot/slack/data/TextMessage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/projectreactor/bot/BotApplicationTests.kt
+++ b/src/test/kotlin/io/projectreactor/bot/BotApplicationTests.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot
 
 import org.junit.Test

--- a/src/test/kotlin/io/projectreactor/bot/config/GitHubPropertiesTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/config/GitHubPropertiesTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.config
 
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/io/projectreactor/bot/github/GithubControllerCompanionObjectTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/github/GithubControllerCompanionObjectTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/io/projectreactor/bot/github/GithubControllerCompanionObjectTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/github/GithubControllerCompanionObjectTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github
 
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/io/projectreactor/bot/github/data/PrUpdateTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/github/data/PrUpdateTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/src/test/kotlin/io/projectreactor/bot/github/data/PullRequestTest.kt
+++ b/src/test/kotlin/io/projectreactor/bot/github/data/PullRequestTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor.bot.github.data
 
 import com.fasterxml.jackson.databind.ObjectMapper


### PR DESCRIPTION
- [build] Add Spotless plugin to enforce copyright header
- compute copyright ranges from git history
- Now apply spotless again to ensure changed files have range 20xx-2021
