### PR TITLE
Update allowed spring boot versions in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,10 @@
     {
       "matchPackageNames": ["com.diffplug.spotless"],
       "allowedVersions": "<6.14"
+    },
+    {
+      "matchPackageNames": ["org.springframework.boot"],
+      "allowedVersions": "<3"
     }
   ]
 }


### PR DESCRIPTION
This project is built with Java 8, while Spring Boot 3 requires Java 17.